### PR TITLE
Suggest adding Pulse "Top-Pick" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A [Model Context Protocol (MCP)](https://www.anthropic.com/news/model-context-protocol) server that enables AI assistants like Claude to interact with your AWS environment. This allows for natural language querying and management of your AWS resources during conversations. Think of better Amazon Q alternative.
 
+<a href="https://www.pulsemcp.com/servers/rafalwilinski-aws"><img src="https://www.pulsemcp.com/badge/top-pick/rafalwilinski-aws" width="400" alt="PulseMCP Badge"></a>
+
 ![AWS MCP](./images/aws-mcp-demo.png)
 
 ## Features


### PR DESCRIPTION
Hey @RafalWilinski,

I'm Mike from [Pulse MCP](https://www.pulsemcp.com/) and we're a community resource that's been around since the inception of the protocol. As MCP has gained widespread adoption, a lot of new servers are coming out daily and we've been thinking about how we can help the community identify the best ones.

We thought yours was a great, early server (you were quick to MCP!) and we had featured you & your server in a [prior newsletter](https://www.pulsemcp.com/posts/newsletter-remote-mcp-images-screen-recording).

We think we've built a brand that folks trust and we thought it would be helpful to start surfacing these badges on the servers we've manually reviewed **and** promoted (while also helping to drive awareness of Pulse).

Do you think this would be valuable to add to your Readme? I've tried to size/place it in a spot I think looks good but would be happy to make any adjustments you'd like.

<img src="https://github.com/user-attachments/assets/ec3fa9b3-95b3-4e5e-bd21-1596d331b325" width=500>

A click on the badge from your Readme will land on your [server's detail page on pulsemcp.com](https://www.pulsemcp.com/servers/rafalwilinski-aws).

A click on that badge while on pulsemcp.com will send users to the [edition of the newsletter where you are featured](https://www.pulsemcp.com/posts/newsletter-remote-mcp-images-screen-recording).

No pressure to add, our feelings won't be hurt and we'll keep the badge on your server's detail page either way.

You can reach me directly at mike@pulsemcp.com if you have any questions or just want to connect. We're always happy to promote folks in the community doing interesting things so reach out any time.